### PR TITLE
Updating android-maven-plugin to version 3.8.0.

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -13,7 +13,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- Plugins -->
-		<android-maven-plugin.version>3.5.0</android-maven-plugin.version>
+		<android-maven-plugin.version>3.8.0</android-maven-plugin.version>
 		<maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
 		<api.platform>16</api.platform>
 


### PR DESCRIPTION
On version 3.5.0 the build was broken on maven 3.1.1.
After update project is build, more importantly it's backwards compatible.
